### PR TITLE
Add themed icon support

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/logo_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/logo_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/logo_launcher_background"/>
     <foreground android:drawable="@mipmap/logo_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/logo_launcher_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/logo_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/logo_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/logo_launcher_background"/>
     <foreground android:drawable="@mipmap/logo_launcher_foreground"/>
+    <monochrome android:drawable="@mipmap/logo_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
# This PR adds support for Android 13's [*Themed App Icons*](https://www.android.com/android-13/#a13-your-phone-your-aesthetic)

## Examples:

- ### Normal icon for reference

###
###   <img src="https://github.com/user-attachments/assets/42123412-c1e3-461c-ae97-7314b3ea2645" width="20%"/>

- ### Light Theme, Pale Pink Swatch
###
###   <img src="https://github.com/user-attachments/assets/34192929-8ea9-4198-8dcd-5aafe2990ccf" width="20%"/>

- ### Dark Theme, Pale Pink Swatch
###
###   <img src="https://github.com/user-attachments/assets/94447831-23f8-4724-8e06-6576b7f0d1fd" width="20%"/>


